### PR TITLE
Update monitor.py

### DIFF
--- a/data_collector/monitor.py
+++ b/data_collector/monitor.py
@@ -8,6 +8,7 @@ import GPUtil
 import subprocess
 import time
 import requests
+import webbrowser
 
 
 def get_ram_temperature():
@@ -94,6 +95,7 @@ if __name__ == '__main__':
     # Start node server:
     # Start the Node.js server
     server_process = subprocess.Popen(["nodejs", "../server/index.js"], stdout=subprocess.PIPE)
+    webbrowser.open('http://localhost:3000/')
     time.sleep(2)
     main()
     server_process.terminate()


### PR DESCRIPTION
Added new import:
import webbrowser

Added required code to allow python to also open the browser automatically instead of the user having to type in the URL address. 

webbrowser.open('http://localhost:3000/')

added at line ninety-eight right after the server_process is completed and the node server is started.