### PR TITLE
Add Files MyPCDashboard.sh AND setup.sh

### DIFF
--- a/MyPCDashboard.sh
+++ b/MyPCDashboard.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+firefox http://localhost:3000/
+python3 "./data_collector/monitor.py"

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Update the pc
+apt-get update
+
+# Install node.js & Node Dependencies
+apt-get install nodejs
+apt-get install npm
+
+npm install express
+npm install socket.io
+
+# Install python & python dependencies
+apt-get install python3
+apt-get install pip
+
+pip install psutil gputil requests pysensors py3nvml


### PR DESCRIPTION
I have added setup.sh to automate installing dependencies on linux/ubuntu I have also added MyPCDashboard.sh which when right click and run as program in ubuntu will auto launch the url in firefox and also start the python3 file monitor.py

overall these changes will allow the program to start up with less command line interaction on linux/ubuntu

Justin Johnson - I have tested and verified that these work. Verified. Pull request. 