### PR TITLE
Update MyPCDashboard.sh

### DIFF
--- a/MyPCDashboard.sh
+++ b/MyPCDashboard.sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-firefox http://localhost:3000/
 python3 "./data_collector/monitor.py"


### PR DESCRIPTION
Removing firefox http call. 

Not needed as the python file monitor.py will handling calling the default browser. (Change needs to occur otherwise two tab's will open which is redundant.)